### PR TITLE
невозможно перевести заказ в confirmed, из-за отсутствия причины

### DIFF
--- a/src/Wikimart/MerchantAPIClient/Client.php
+++ b/src/Wikimart/MerchantAPIClient/Client.php
@@ -317,7 +317,7 @@ class Client
             throw new InvalidArgumentException( 'Valid values for argument \'$status\' is: ' . implode( ', ', $this->validStatuses ) );
         }
 
-        if ( !is_integer( $reasonID ) ) {
+        if ( !is_null( $reasonID ) && !is_integer( $reasonID ) ) {
             throw new InvalidArgumentException( 'Argument \'$reasonID\' must be integer' );
         }
 


### PR DESCRIPTION
Исправлена нестыковка api и клиента по поводу параметра reasonId при смене статуса